### PR TITLE
Gen_Extract copies instead of removing from the results list

### DIFF
--- a/include/aunit/framework/aunit-reporter.ads
+++ b/include/aunit/framework/aunit-reporter.ads
@@ -43,7 +43,7 @@ package AUnit.Reporter is
 
    procedure Report
      (Engine  : Reporter;
-      R       : in out Result'Class;
+      R       : Result'Class;
       Options : AUnit_Options := Default_Options) is abstract;
    --  This procedure is called by AUnit.Run to report the result after running
    --  the whole testsuite (or the selected subset of tests).

--- a/include/aunit/framework/aunit-test_results.adb
+++ b/include/aunit/framework/aunit-test_results.adb
@@ -59,7 +59,7 @@ package body AUnit.Test_Results is
 
    generic
       with function Test (Position : Result_Lists.Cursor) return Boolean;
-   procedure Gen_Extract (R : in out Result;
+   procedure Gen_Extract (R : Result;
                           E : in out Result_Lists.List);
 
    -------------------
@@ -102,7 +102,7 @@ package body AUnit.Test_Results is
    -----------------
 
    procedure Gen_Extract
-     (R : in out Result;
+     (R : Result;
       E : in out Result_Lists.List)
    is
       C : Result_Lists.Cursor;
@@ -233,7 +233,7 @@ package body AUnit.Test_Results is
    -- Errors --
    ------------
 
-   procedure Errors (R : in out Result;
+   procedure Errors (R : Result;
                      E : in out Result_Lists.List) is
       procedure Extract is new Gen_Extract (Is_Error);
    begin
@@ -256,7 +256,7 @@ package body AUnit.Test_Results is
    -- Failures --
    --------------
 
-   procedure Failures (R : in out Result;
+   procedure Failures (R : Result;
                        F : in out Result_Lists.List) is
       procedure Extract is new Gen_Extract (Is_Failure);
    begin
@@ -296,7 +296,7 @@ package body AUnit.Test_Results is
    -- Successes --
    ---------------
 
-   procedure Successes (R : in out Result;
+   procedure Successes (R : Result;
                         S : in out Result_Lists.List) is
       procedure Extract is new Gen_Extract (Is_Success);
    begin

--- a/include/aunit/framework/aunit-test_results.adb
+++ b/include/aunit/framework/aunit-test_results.adb
@@ -106,28 +106,15 @@ package body AUnit.Test_Results is
       E : in out Result_Lists.List)
    is
       C : Result_Lists.Cursor;
-      Prev : Result_Lists.Cursor;
       use Result_Lists;
    begin
       C := First (R.Result_List);
-      Prev := No_Element;
 
       while Has_Element (C) loop
          if Test (C) then
-            Splice (Target   => E,
-                    Before   => No_Element,
-                    Source   => R.Result_List,
-                    Position => C);
-
-            if Prev = No_Element then
-               C := First (R.Result_List);
-            else
-               C := Next (Prev);
-            end if;
-         else
-            Prev := C;
-            Next (C);
+            E.Append (Element (C));
          end if;
+         Next (C);
       end loop;
    end Gen_Extract;
 

--- a/include/aunit/framework/aunit-test_results.ads
+++ b/include/aunit/framework/aunit-test_results.ads
@@ -33,13 +33,13 @@ with Ada_Containers.AUnit_Lists;
 
 with AUnit.Time_Measure; use AUnit.Time_Measure;
 
---  Test reporting.
+--  Test reporting
 --
 package AUnit.Test_Results is
 
    type Result is tagged limited private;
    --  Record result. A result object is associated with the execution of a
-   --  top-level test suite.
+   --  top-level test suite
 
    type Test_Failure is record
       Message     : Message_String;
@@ -104,13 +104,13 @@ package AUnit.Test_Results is
 
    procedure Errors (R : in out Result;
                      E : in out Result_Lists.List);
-   --  List of routines with unexpected exceptions. This resets the list.
+   --  List of routines with unexpected exceptions
 
    function Failure_Count (R : Result) return Count_Type;
    --  Number of failed routines
 
    procedure Failures (R : in out Result; F : in out Result_Lists.List);
-   --  List of failed routines. This resets the list.
+   --  List of failed routines
 
    function Elapsed (R : Result) return Time;
    --  Elapsed time for test execution
@@ -122,7 +122,7 @@ package AUnit.Test_Results is
    --  Number of successful routines
 
    procedure Successes (R : in out Result; S : in out Result_Lists.List);
-   --  List of successful routines. This resets the list.
+   --  List of successful routines
 
    function Successful (R : Result) return Boolean;
    --  All routines successful?

--- a/include/aunit/framework/aunit-test_results.ads
+++ b/include/aunit/framework/aunit-test_results.ads
@@ -102,14 +102,14 @@ package AUnit.Test_Results is
    function Error_Count (R : Result) return Count_Type;
    --  Number of routines with unexpected exceptions
 
-   procedure Errors (R : in out Result;
+   procedure Errors (R : Result;
                      E : in out Result_Lists.List);
    --  List of routines with unexpected exceptions
 
    function Failure_Count (R : Result) return Count_Type;
    --  Number of failed routines
 
-   procedure Failures (R : in out Result; F : in out Result_Lists.List);
+   procedure Failures (R : Result; F : in out Result_Lists.List);
    --  List of failed routines
 
    function Elapsed (R : Result) return Time;
@@ -121,7 +121,7 @@ package AUnit.Test_Results is
    function Success_Count (R : Result) return Count_Type;
    --  Number of successful routines
 
-   procedure Successes (R : in out Result; S : in out Result_Lists.List);
+   procedure Successes (R : Result; S : in out Result_Lists.List);
    --  List of successful routines
 
    function Successful (R : Result) return Boolean;

--- a/include/aunit/reporters/aunit-reporter-gnattest.adb
+++ b/include/aunit/reporters/aunit-reporter-gnattest.adb
@@ -85,7 +85,7 @@ package body  AUnit.Reporter.GNATtest is
    ------------
 
    procedure Report (Engine  : GNATtest_Reporter;
-                     R       : in out Result'Class;
+                     R       : Result'Class;
                      Options : AUnit_Options := Default_Options)
    is
       File : File_Type renames Engine.File.all;

--- a/include/aunit/reporters/aunit-reporter-gnattest.ads
+++ b/include/aunit/reporters/aunit-reporter-gnattest.ads
@@ -36,6 +36,6 @@ package AUnit.Reporter.GNATtest is
    type GNATtest_Reporter is new Reporter with null record;
 
    procedure Report (Engine  : GNATtest_Reporter;
-                     R       : in out Result'Class;
+                     R       : Result'Class;
                      Options : AUnit_Options := Default_Options);
 end AUnit.Reporter.GNATtest;

--- a/include/aunit/reporters/aunit-reporter-text.adb
+++ b/include/aunit/reporters/aunit-reporter-text.adb
@@ -48,12 +48,12 @@ package body AUnit.Reporter.Text is
    --  Report a single assertion failure or unexpected exception
 
    generic
-      with procedure Get (R : in out Result; L : in out Result_Lists.List);
+      with procedure Get (R : Result; L : in out Result_Lists.List);
       Label : String;
       Color : String;
    procedure Report_Tests
       (Engine : Text_Reporter;
-       R      : in out Result'Class;
+       R      : Result'Class;
        File   : File_Type);
    --  Report a series of tests
 
@@ -113,7 +113,7 @@ package body AUnit.Reporter.Text is
 
    procedure Report_Tests
       (Engine : Text_Reporter;
-       R      : in out Result'Class;
+       R      : Result'Class;
        File   : File_Type)
    is
       S : Result_Lists.List;
@@ -136,7 +136,7 @@ package body AUnit.Reporter.Text is
 
    procedure Report_OK_Tests
       (Engine : Text_Reporter;
-       R      : in out Result'Class)
+       R      : Result'Class)
    is
       procedure Internal is new Report_Tests (Successes, "OK", ANSI_Green);
    begin
@@ -145,7 +145,7 @@ package body AUnit.Reporter.Text is
 
    procedure Report_Fail_Tests
       (Engine : Text_Reporter;
-       R      : in out Result'Class)
+       R      : Result'Class)
    is
       procedure Internal is new Report_Tests (Failures, "FAIL", ANSI_Purple);
    begin
@@ -154,7 +154,7 @@ package body AUnit.Reporter.Text is
 
    procedure Report_Error_Tests
       (Engine : Text_Reporter;
-       R      : in out Result'Class)
+       R      : Result'Class)
    is
       procedure Internal is new Report_Tests (Errors, "ERROR", ANSI_Red);
    begin
@@ -167,7 +167,7 @@ package body AUnit.Reporter.Text is
 
    procedure Report
      (Engine  : Text_Reporter;
-      R       : in out Result'Class;
+      R       : Result'Class;
       Options : AUnit_Options := Default_Options)
    is
       File    : File_Type renames Engine.File.all;

--- a/include/aunit/reporters/aunit-reporter-text.ads
+++ b/include/aunit/reporters/aunit-reporter-text.ads
@@ -42,15 +42,15 @@ package AUnit.Reporter.Text is
    --  By default, no color is used.
 
    procedure Report (Engine  : Text_Reporter;
-                     R       : in out Result'Class;
+                     R       : Result'Class;
                      Options : AUnit_Options := Default_Options);
 
    procedure Report_OK_Tests (Engine : Text_Reporter;
-                              R      : in out Result'Class);
+                              R      : Result'Class);
    procedure Report_Fail_Tests (Engine : Text_Reporter;
-                                R      : in out Result'Class);
+                                R      : Result'Class);
    procedure Report_Error_Tests (Engine : Text_Reporter;
-                                 R      : in out Result'Class);
+                                 R      : Result'Class);
    --  These subprograms implement the various parts of the Report. You
    --  can therefore chose in which order to report the various categories,
    --  and whether or not to report them.

--- a/include/aunit/reporters/aunit-reporter-xml.adb
+++ b/include/aunit/reporters/aunit-reporter-xml.adb
@@ -71,7 +71,7 @@ package body AUnit.Reporter.XML is
    ------------
 
    procedure Report (Engine  : XML_Reporter;
-                     R       : in out Result'Class;
+                     R       : Result'Class;
                      Options : AUnit_Options := Default_Options)
    is
       T    : AUnit_Duration;

--- a/include/aunit/reporters/aunit-reporter-xml.ads
+++ b/include/aunit/reporters/aunit-reporter-xml.ads
@@ -35,6 +35,6 @@ package AUnit.Reporter.XML is
    type XML_Reporter is new Reporter with null record;
 
    procedure Report (Engine  : XML_Reporter;
-                     R       : in out Result'Class;
+                     R       : Result'Class;
                      Options : AUnit_Options := Default_Options);
 end AUnit.Reporter.XML;


### PR DESCRIPTION
Gen_Extract now copies into the list given without clobbering the existing results list. This makes it possible to generate two reports in sequence. Without this you would get incorrect output if you did that:

```
Total Tests Run:   1
Successful Tests:  0
Failed Assertions: 0
Unexpected Errors: 0
Cumulative Time: 0.000004 sec. seconds
```

This is because the total tally is simply an integer field that is not updated, while the actual lists that are consulted when asking how many successful tests there were are destroyed when you try to retrieve the succeeded, failed or errored tests.

The comments around the functions still need to be updated to remove the note about it 'resetting' lists.