### PR TITLE
Fix indent of Integer output (T518-036)

### DIFF
--- a/include/aunit/framework/nofileio/aunit-io.adb
+++ b/include/aunit/framework/nofileio/aunit-io.adb
@@ -40,8 +40,10 @@ package body AUnit.IO is
      (Standard_Out'Access);
 
    procedure Put (File : File_Type;
-                  Item : Integer) is
-      pragma Unreferenced (File);
+                  Item : Integer;
+                  Width : Integer := 0;
+                  Base  : Integer := 0) is
+      pragma Unreferenced (File, Width, Base);
    begin
       Put (Item);
    end Put;

--- a/include/aunit/framework/nofileio/aunit-io.ads
+++ b/include/aunit/framework/nofileio/aunit-io.ads
@@ -39,7 +39,9 @@ package AUnit.IO is
      return File_Access;
 
    procedure Put (File : File_Type;
-                  Item : Integer);
+                  Item : Integer;
+                  Width : Integer := 0;
+                  Base  : Integer := 0);
 
    procedure Put (File : File_Type;
                   Item : String);

--- a/include/aunit/reporters/aunit-reporter-gnattest.adb
+++ b/include/aunit/reporters/aunit-reporter-gnattest.adb
@@ -124,13 +124,13 @@ package body  AUnit.Reporter.GNATtest is
          Dump_Result_List (File, E);
       end;
 
-      Put      (File, Tests_Count);
+      Put      (File, Tests_Count, 0);
       Put      (File, " tests run: ");
-      Put      (File, Passed_Count);
+      Put      (File, Passed_Count, 0);
       Put      (File, " passed; ");
-      Put      (File, Failures_Count);
+      Put      (File, Failures_Count, 0);
       Put      (File, " failed; ");
-      Put      (File, Crashes_Count);
+      Put      (File, Crashes_Count, 0);
       Put_Line (File, " crashed.");
 
    end Report;

--- a/include/aunit/reporters/aunit-reporter-text.adb
+++ b/include/aunit/reporters/aunit-reporter-text.adb
@@ -186,16 +186,16 @@ package body AUnit.Reporter.Text is
 
       New_Line (File);
       Put (File, "Total Tests Run:   ");
-      Put (File, Integer (Test_Count (R)));
+      Put (File, Integer (Test_Count (R)), 0);
       New_Line (File);
       Put (File, "Successful Tests:  ");
-      Put (File, S_Count);
+      Put (File, S_Count, 0);
       New_Line (File);
       Put (File, "Failed Assertions: ");
-      Put (File, F_Count);
+      Put (File, F_Count, 0);
       New_Line (File);
       Put (File, "Unexpected Errors: ");
-      Put (File, E_Count);
+      Put (File, E_Count, 0);
       New_Line (File);
 
       if Elapsed (R) /= Time_Measure.Null_Time then

--- a/include/aunit/reporters/aunit-reporter-xml.adb
+++ b/include/aunit/reporters/aunit-reporter-xml.adb
@@ -93,16 +93,16 @@ package body AUnit.Reporter.XML is
 
       Put_Line (File, "  <Statistics>");
       Put      (File, "    <Tests>");
-      Put (File, Integer (Test_Count (R)));
+      Put (File, Integer (Test_Count (R)), 0);
       Put_Line (File, "</Tests>");
       Put      (File, "    <FailuresTotal>");
-      Put (File, Integer (Failure_Count (R) + Error_Count (R)));
+      Put (File, Integer (Failure_Count (R) + Error_Count (R)), 0);
       Put_Line (File, "</FailuresTotal>");
       Put      (File, "    <Failures>");
-      Put (File, Integer (Failure_Count (R)));
+      Put (File, Integer (Failure_Count (R)), 0);
       Put_Line (File, "</Failures>");
       Put      (File, "    <Errors>");
-      Put (File, Integer (Error_Count (R)));
+      Put (File, Integer (Error_Count (R)), 0);
       Put_Line (File, "</Errors>");
       Put_Line (File, "  </Statistics>");
 


### PR DESCRIPTION
Unify profile of Put for Integer in both AUnit.IO packages.
Fix indents of test amounts in all reporters for full runtimes.