### PR TITLE
Add an explicit type qualifier for an access parameter

### DIFF
--- a/examples/simple_test/tests/math_suite.adb
+++ b/examples/simple_test/tests/math_suite.adb
@@ -1,6 +1,7 @@
 --
 --  Copyright (C) 2008, AdaCore
 --
+with AUnit.Simple_Test_Cases; use AUnit.Simple_Test_Cases;
 with Math.Test;
 
 package body Math_Suite is
@@ -8,7 +9,7 @@ package body Math_Suite is
    function Suite return Access_Test_Suite is
       Ret : constant Access_Test_Suite := new Test_Suite;
    begin
-      Ret.Add_Test (new Math.Test.Test);
+      Ret.Add_Test (Test_Case_Access'(new Math.Test.Test));
       return Ret;
    end Suite;
 


### PR DESCRIPTION
This removes a warning from standard error, that some testsuites
detect as a failure.
Thanks.