### PR TITLE
fixed some of the copyright headers

### DIFF
--- a/include/aunit/framework/aunit-reporter.adb
+++ b/include/aunit/framework/aunit-reporter.adb
@@ -2,9 +2,9 @@
 --                                                                          --
 --                         GNAT COMPILER COMPONENTS                         --
 --                                                                          --
---                   A U N I T . R E P O R T E R . T E X T                  --
+--                        A U N I T . R E P O R T E R                       --
 --                                                                          --
---                                 S p e c                                  --
+--                                 B o d y                                  --
 --                                                                          --
 --                                                                          --
 --                      Copyright (C) 2019, AdaCore                         --

--- a/include/aunit/framework/aunit-test_filters.adb
+++ b/include/aunit/framework/aunit-test_filters.adb
@@ -2,9 +2,9 @@
 --                                                                          --
 --                         GNAT COMPILER COMPONENTS                         --
 --                                                                          --
---                          A U N I T . T E S T S                           --
+--                    A U N I T . T E S T _ F I L T E R S                   --
 --                                                                          --
---                                 S p e c                                  --
+--                                 B o d y                                  --
 --                                                                          --
 --                   Copyright (C) 2009-2011, AdaCore                       --
 --                                                                          --

--- a/include/aunit/framework/nofileio/aunit-io.adb
+++ b/include/aunit/framework/nofileio/aunit-io.adb
@@ -2,9 +2,9 @@
 --                                                                          --
 --                         GNAT COMPILER COMPONENTS                         --
 --                                                                          --
---                        A U N I T . R E P O R T E R                       --
+--                              A U N I T . I O                             --
 --                                                                          --
---                                 S p e c                                  --
+--                                 B o d y                                  --
 --                                                                          --
 --                                                                          --
 --                       Copyright (C) 2019, AdaCore                        --


### PR DESCRIPTION
I noticed a few of the copyright headers erroneously call a body a spec and vice versa.
You can verify with:
``` 
find . -type f -iname "*.adb" | xargs -I{} grep -n -i "S p e c" "{}" /dev/null
find . -type f -iname "*.ads" | xargs -I{} grep -n -i "B o d y" "{}" /dev/null
```

I say 'fixed some of' because there may still be incorrect package names; I didn't check that and don't care to.