### PR TITLE
Removed invalid -gnat05 flag

### DIFF
--- a/examples/calculator/harness.gpr
+++ b/examples/calculator/harness.gpr
@@ -26,7 +26,7 @@ project Harness is
    package Compiler is
       for Default_Switches ("ada") use
         ("-g", "-gnatQ", "-O1", "-gnatf", "-gnato",
-         "-gnatwa.Xe", "-gnaty", "-gnat05");
+         "-gnatwa.Xe", "-gnaty");
    end Compiler;
 
 end Harness;

--- a/examples/calculator/tested_lib/testlib.gpr
+++ b/examples/calculator/tested_lib/testlib.gpr
@@ -13,7 +13,7 @@ project TestLib is
 
    package Compiler is
       for Default_Switches ("ada") use
-        ("-g", "-O0", "-gnat05", "-gnatwae", "-gnaty", "-gnata");
+        ("-g", "-O0", "-gnatwae", "-gnaty", "-gnata");
       case Coverage is
       when "yes" =>
          for Default_Switches ("ada") use Compiler'Default_Switches ("ada") &

--- a/examples/failures/harness.gpr
+++ b/examples/failures/harness.gpr
@@ -20,7 +20,7 @@ project Harness is
    package Compiler is
       for Default_Switches ("ada") use
         ("-g", "-gnatQ", "-O1", "-gnatf", "-gnato",
-         "-gnatwa.Xe", "-gnaty", "-gnat05");
+         "-gnatwa.Xe", "-gnaty");
    end Compiler;
 
 end Harness;

--- a/examples/failures/tested_lib/testlib.gpr
+++ b/examples/failures/tested_lib/testlib.gpr
@@ -10,7 +10,7 @@ project TestLib is
 
    package Compiler is
       for Default_Switches ("ada") use
-            ("-g", "-O1", "-gnat05", "-gnatwa.Xe", "-gnaty", "-gnato", "-gnatf");
+            ("-g", "-O1", "-gnatwa.Xe", "-gnaty", "-gnato", "-gnatf");
    end Compiler;
 
 end TestLib;

--- a/examples/liskov/harness.gpr
+++ b/examples/liskov/harness.gpr
@@ -20,7 +20,7 @@ project Harness is
    package Compiler is
       for Default_Switches ("ada") use
         ("-g", "-gnatQ", "-O1", "-gnatf", "-gnato",
-         "-gnatwa.Xe", "-gnaty", "-gnat05");
+         "-gnatwa.Xe", "-gnaty");
    end Compiler;
 
 end Harness;

--- a/examples/liskov/tested_lib/testlib.gpr
+++ b/examples/liskov/tested_lib/testlib.gpr
@@ -10,7 +10,7 @@ project TestLib is
 
    package Compiler is
       for Default_Switches ("ada") use
-            ("-g", "-O1", "-gnat05", "-gnatwa.Xe", "-gnaty", "-gnata", "-gnatf");
+            ("-g", "-O1", "-gnatwa.Xe", "-gnaty", "-gnata", "-gnatf");
    end Compiler;
 
 end TestLib;

--- a/examples/simple_test/harness.gpr
+++ b/examples/simple_test/harness.gpr
@@ -20,7 +20,7 @@ project Harness is
    package Compiler is
       for Default_Switches ("ada") use
         ("-g", "-gnatQ", "-O1", "-gnatf", "-gnato",
-         "-gnatwa.Xe", "-gnaty", "-gnat05");
+         "-gnatwa.Xe", "-gnaty");
    end Compiler;
 
 end Harness;

--- a/examples/simple_test/tested_lib/testlib.gpr
+++ b/examples/simple_test/tested_lib/testlib.gpr
@@ -10,7 +10,7 @@ project TestLib is
 
    package Compiler is
       for Default_Switches ("ada") use
-            ("-g", "-O1", "-gnat05", "-gnatwa.Xe", "-gnaty", "-gnata", "-gnatf");
+            ("-g", "-O1", "-gnatwa.Xe", "-gnaty", "-gnata", "-gnatf");
    end Compiler;
 
 end TestLib;

--- a/examples/test_caller/harness/harness.gpr
+++ b/examples/test_caller/harness/harness.gpr
@@ -20,7 +20,7 @@ project Harness is
    package Compiler is
       for Default_Switches ("ada") use
         ("-g", "-gnatQ", "-O1", "-gnatf", "-gnato",
-         "-gnatwa.Xe", "-gnaty", "-gnat05");
+         "-gnatwa.Xe", "-gnaty");
    end Compiler;
 
 end Harness;

--- a/examples/test_caller/tested_lib/testlib.gpr
+++ b/examples/test_caller/tested_lib/testlib.gpr
@@ -10,7 +10,7 @@ project TestLib is
 
    package Compiler is
       for Default_Switches ("ada") use
-            ("-g", "-O1", "-gnat05", "-gnatwa.Xe", "-gnaty", "-gnata", "-gnatf");
+            ("-g", "-O1", "-gnatwa.Xe", "-gnaty", "-gnata", "-gnatf");
    end Compiler;
 
 end TestLib;

--- a/examples/test_fixture/harness.gpr
+++ b/examples/test_fixture/harness.gpr
@@ -20,7 +20,7 @@ project Harness is
    package Compiler is
       for Default_Switches ("ada") use
         ("-g", "-gnatQ", "-O1", "-gnatf", "-gnato",
-         "-gnatwa.Xe", "-gnaty", "-gnat05");
+         "-gnatwa.Xe", "-gnaty");
    end Compiler;
 
 end Harness;

--- a/examples/test_fixture/tested_lib/testlib.gpr
+++ b/examples/test_fixture/tested_lib/testlib.gpr
@@ -10,7 +10,7 @@ project TestLib is
 
    package Compiler is
       for Default_Switches ("ada") use
-            ("-g", "-O1", "-gnat05", "-gnatwa.Xe", "-gnaty", "-gnata", "-gnatf");
+            ("-g", "-O1", "-gnatwa.Xe", "-gnaty", "-gnata", "-gnatf");
    end Compiler;
 
 end TestLib;


### PR DESCRIPTION
Gnat just gives this error message when encountering the -gnat05 flag:

```
invalid switch -gnat05
```

And since we are living in 2020 and so Ada2005 support goes without saying, we might as well remove this flag now.