### PR TITLE
Return in out mode for Result parameter of Report

### DIFF
--- a/include/aunit/framework/aunit-reporter.ads
+++ b/include/aunit/framework/aunit-reporter.ads
@@ -43,7 +43,7 @@ package AUnit.Reporter is
 
    procedure Report
      (Engine  : Reporter;
-      R       : Result'Class;
+      R       : in out Result'Class;
       Options : AUnit_Options := Default_Options) is abstract;
    --  This procedure is called by AUnit.Run to report the result after running
    --  the whole testsuite (or the selected subset of tests).

--- a/include/aunit/reporters/aunit-reporter-gnattest.adb
+++ b/include/aunit/reporters/aunit-reporter-gnattest.adb
@@ -85,7 +85,7 @@ package body  AUnit.Reporter.GNATtest is
    ------------
 
    procedure Report (Engine  : GNATtest_Reporter;
-                     R       : Result'Class;
+                     R       : in out Result'Class;
                      Options : AUnit_Options := Default_Options)
    is
       File : File_Type renames Engine.File.all;

--- a/include/aunit/reporters/aunit-reporter-gnattest.ads
+++ b/include/aunit/reporters/aunit-reporter-gnattest.ads
@@ -36,6 +36,6 @@ package AUnit.Reporter.GNATtest is
    type GNATtest_Reporter is new Reporter with null record;
 
    procedure Report (Engine  : GNATtest_Reporter;
-                     R       : Result'Class;
+                     R       : in out Result'Class;
                      Options : AUnit_Options := Default_Options);
 end AUnit.Reporter.GNATtest;

--- a/include/aunit/reporters/aunit-reporter-text.adb
+++ b/include/aunit/reporters/aunit-reporter-text.adb
@@ -167,7 +167,7 @@ package body AUnit.Reporter.Text is
 
    procedure Report
      (Engine  : Text_Reporter;
-      R       : Result'Class;
+      R       : in out Result'Class;
       Options : AUnit_Options := Default_Options)
    is
       File    : File_Type renames Engine.File.all;

--- a/include/aunit/reporters/aunit-reporter-text.ads
+++ b/include/aunit/reporters/aunit-reporter-text.ads
@@ -42,7 +42,7 @@ package AUnit.Reporter.Text is
    --  By default, no color is used.
 
    procedure Report (Engine  : Text_Reporter;
-                     R       : Result'Class;
+                     R       : in out Result'Class;
                      Options : AUnit_Options := Default_Options);
 
    procedure Report_OK_Tests (Engine : Text_Reporter;

--- a/include/aunit/reporters/aunit-reporter-xml.adb
+++ b/include/aunit/reporters/aunit-reporter-xml.adb
@@ -71,7 +71,7 @@ package body AUnit.Reporter.XML is
    ------------
 
    procedure Report (Engine  : XML_Reporter;
-                     R       : Result'Class;
+                     R       : in out Result'Class;
                      Options : AUnit_Options := Default_Options)
    is
       T    : AUnit_Duration;

--- a/include/aunit/reporters/aunit-reporter-xml.ads
+++ b/include/aunit/reporters/aunit-reporter-xml.ads
@@ -35,6 +35,6 @@ package AUnit.Reporter.XML is
    type XML_Reporter is new Reporter with null record;
 
    procedure Report (Engine  : XML_Reporter;
-                     R       : Result'Class;
+                     R       : in out Result'Class;
                      Options : AUnit_Options := Default_Options);
 end AUnit.Reporter.XML;


### PR DESCRIPTION
Partially revert changes done when making reporters not
erasing test results. Result parameter of Report should be kept
as in out to allow compatibility with existing custom reporters.

for TB02-012