### PR TITLE
Use zfp exceptions for cert runtimes

### DIFF
--- a/lib/gnat/aunit_shared.gpr
+++ b/lib/gnat/aunit_shared.gpr
@@ -49,7 +49,7 @@ project AUnit_Shared is
          Memory := "staticmemory";
          FileIO := "nofileio";
       when "cert" =>
-         Except := "certexception";
+         Except := "zfpexception";
          Memory := "staticmemory";
          FileIO := "nofileio";
       when others =>


### PR DESCRIPTION
The vx7r2cert runtime does not support exception propagation
anymore so aunit can only be built with zfp exception support
with this runtime.

TN: U216-006