### PR TITLE
Remove redundant "with" of parent unit in aunit-test_suites-tests.ads

### DIFF
--- a/test/src/aunit-test_suites-tests.ads
+++ b/test/src/aunit-test_suites-tests.ads
@@ -1,10 +1,9 @@
 --
---  Copyright (C) 2009-2010, AdaCore
+--  Copyright (C) 2009-2021, AdaCore
 --
 
 with AUnit.Test_Fixtures;
 with AUnit.Test_Results;
-with AUnit.Test_Suites;
 
 package AUnit.Test_Suites.Tests is
 


### PR DESCRIPTION
This fixes a warning raised by recent GNAT toolchains.

TN: UC13-054