### PR TITLE
master

### DIFF
--- a/examples/calculator/tests/operations-addition-test.ads
+++ b/examples/calculator/tests/operations-addition-test.ads
@@ -1,8 +1,7 @@
 --
---  Copyright (C) 2008, AdaCore
+--  Copyright (C) 2021, AdaCore
 --
 with Operations.Binary.Gen_Test;
-with Operations.Addition;
 with Operations.Addition_Test_Fixture; use Operations.Addition_Test_Fixture;
 package Operations.Addition.Test is new Operations.Addition.Gen_Test
   (Set_Up);

--- a/examples/calculator/tests/operations-subtraction-test.ads
+++ b/examples/calculator/tests/operations-subtraction-test.ads
@@ -1,8 +1,7 @@
 --
---  Copyright (C) 2008, AdaCore
+--  Copyright (C) 2021, AdaCore
 --
 with Operations.Binary.Gen_Test;
-with Operations.Subtraction;
 with Operations.Subtraction_Test_Fixture;
 use Operations.Subtraction_Test_Fixture;
 package Operations.Subtraction.Test is new Operations.Subtraction.Gen_Test

--- a/test/src/aunit-test_suites-tests.ads
+++ b/test/src/aunit-test_suites-tests.ads
@@ -1,10 +1,9 @@
 --
---  Copyright (C) 2009-2010, AdaCore
+--  Copyright (C) 2009-2021, AdaCore
 --
 
 with AUnit.Test_Fixtures;
 with AUnit.Test_Results;
-with AUnit.Test_Suites;
 
 package AUnit.Test_Suites.Tests is
 


### PR DESCRIPTION
- Remove redundant "with" of parent unit
- Remove unnecessary with of ancestor, which causes warnings in recent GNAT.
