### PR TITLE
Setting large code model for kernel RTS on 64 bits architectures.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,22 @@ CONF_ARGS = $(TARGET_CONF) $(RTS_CONF)
 GPROPTS = $(CONF_ARGS) -XAUNIT_BUILD_MODE=$(MODE) -XAUNIT_RUNTIME=$(RTS) \
 		-XAUNIT_PLATFORM=$(TARGET)
 
+# For the 64 bits architectures, the large code model has to be used.
+# with rtp-large, gprconfig ensures that -mcmodel=large is used,
+# but it is managed here for the default (kernel).
+GPROPTS_EXTRA=
+ifneq ($(strip $(filter aarch64-wrs-vxworks7r2 powerpc64-wrs-vxworks7r2 x86_64-wrs-vxworks7r2,$(TARGET))),)
+ifeq (${RTS_CONF},)
+# This covers the kernel RTS because for rtp, the RTS_OPT variable is defined to --RTS=rtp.
+# kernel is the default and the RTS_OPT is not set in that case.
+GPROPTS_EXTRA+=-cargs -mcmodel=large -largs -mcmodel=large
+endif
+endif
+
 .PHONY: all clean targets install_clean install
 
 all:
-	$(GPRBUILD) -p $(GPROPTS) lib/gnat/aunit.gpr
+	$(GPRBUILD) -p $(GPROPTS) lib/gnat/aunit.gpr ${GPROPTS_EXTRA}
 
 clean-lib:
 	$(RM) -fr lib/aunit lib/aunit-obj


### PR DESCRIPTION
The large code model which is now the default for kernel RTS
(not triggered by the large multilib anymore) on 64 bits
architectures.

TN: UB03-045
Tested-with: $ anod test cross-testsuite \
   --target=x86_64-vx7r2,7.2,vxsim-64 \
   --qualifier=rts=kernel
   $ anod test cross-testsuite \
   --target=aarch64-vx7r2,7.2,vxsim-64 \
   --qualifier=rts=kernel
   $ anod test cross-testsuite \
   --target=ppc64-vx7r2,7.2,vxsim-64 \
   --qualifier=rts=kernel