### PR TITLE
Fix compilation warnings

### DIFF
--- a/include/aunit/containers/ada_containers-aunit_lists.adb
+++ b/include/aunit/containers/ada_containers-aunit_lists.adb
@@ -622,7 +622,6 @@ package body Ada_Containers.AUnit_Lists is
       Count     : Count_Type := 1)
    is
       Position : Cursor;
-      pragma Unreferenced (Position);
    begin
       Insert (Container, Before, New_Item, Position, Count);
    end Insert;

--- a/include/aunit/framework/aunit-run.adb
+++ b/include/aunit/framework/aunit-run.adb
@@ -82,7 +82,6 @@ package body AUnit.Run is
    is
       Results : Test_Results.Result;
       Outcome : Status;
-      pragma Unreferenced (Outcome);
    begin
       Test_Results.Clear (Results);
       Run (Suite, Results, Options, Reporter, Outcome);
@@ -115,7 +114,6 @@ package body AUnit.Run is
       Options  : AUnit.Options.AUnit_Options := AUnit.Options.Default_Options)
    is
       Outcome : Status;
-      pragma Unreferenced (Outcome);
    begin
       Run (Suite, Results, Options, Reporter, Outcome);
    end Test_Runner_With_Results;


### PR DESCRIPTION
Remove pragmas Unrefferenced that are now
causing compilation warnings.

TN: V609-072