### PR TITLE
Switch the HTML documentation to using the RTD theme

### DIFF
--- a/doc/share/conf.py
+++ b/doc/share/conf.py
@@ -56,7 +56,7 @@ for d in os.listdir(root_source_dir):
         exclude_patterns.append(d)
         print('ignoring %s' % d)
 
-extensions = []
+extensions = ['sphinx_rtd_theme']
 templates_path = ['_templates']
 source_suffix = '.rst'
 master_doc = doc_name
@@ -70,7 +70,7 @@ version = get_version()
 release = get_version()
 
 pygments_style = None
-html_theme = 'sphinxdoc'
+html_theme = 'sphinx_rtd_theme'
 if os.path.isfile('adacore_transparent.png'):
     html_logo = 'adacore_transparent.png'
 if os.path.isfile('favicon.ico'):


### PR DESCRIPTION
This commit adjust the sphinx configuration to use the "Read The Docs" theme, which has the advantage of allowing the navigation bar (containing among other things a search bar, and the TOC) to stay fixed while scrolling the contents of the page being read. This is particularly useful to allow access to those features while reading a long page, for instance.

TN: VB25-024