### PR TITLE
For cert runtimes use certexception and calendar

### DIFF
--- a/lib/gnat/aunit_shared.gpr
+++ b/lib/gnat/aunit_shared.gpr
@@ -45,12 +45,12 @@ project AUnit_Shared is
          FileIO := "nofileio";
       when "ravenscar-cert" =>
          Except := "certexception";
-         Calend := "nocalendar";
+         Calend := "calendar";
          Memory := "staticmemory";
          FileIO := "nofileio";
       when "cert" =>
-         Except := "zfpexception";
-         Calend := "nocalendar";
+         Except := "certexception";
+         Calend := "calendar";
          Memory := "staticmemory";
          FileIO := "nofileio";
       when others =>


### PR DESCRIPTION
This reverts the changes in U216-007, as the new cert based runtime for vx7r2 ended up with a new name while the old cert runtime remains for other platforms like Deos.

TN: VA20-029