### PR TITLE
Fix warning: renamed predefined unit is an obsolescent feature (RM J.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.o
 *.ali
 lib/aunit*
+alire

--- a/alire.toml
+++ b/alire.toml
@@ -1,0 +1,16 @@
+description = "Ada unit test framework"
+name = "aunit"
+version = "25.0.0-dev"
+authors = ["AdaCore"]
+licenses = "GPL-3.0-or-later WITH GCC-exception-3.1"
+maintainers = ["chouteau@adacore.com"]
+maintainers-logins = ["Fabien-Chouteau"]
+project-files = ["lib/gnat/aunit.gpr"]
+tags=["unit", "test", "unit-test"]
+
+[configuration]
+disabled = true
+
+[gpr-externals]
+AUNIT_BUILD_MODE = ["Devel", "Install"]
+AUNIT_RUNTIME = ["full", "zfp", "zfp-cross", "ravenscar", "ravenscar-cert", "cert"]

--- a/include/aunit/framework/aunit-test_cases.adb
+++ b/include/aunit/framework/aunit-test_cases.adb
@@ -61,6 +61,9 @@ package body AUnit.Test_Cases is
    ----------------------
 
    function Call_Set_Up_Case
+     (Test : in out Test_Case'Class) return Test_Error_Access;
+
+   function Call_Set_Up_Case
      (Test : in out Test_Case'Class) return Test_Error_Access is separate;
 
    ---------

--- a/include/aunit/framework/staticmemory/aunit-memory.adb
+++ b/include/aunit/framework/staticmemory/aunit-memory.adb
@@ -32,7 +32,7 @@
 --  Dummy implementation.
 
 with System.Storage_Elements;
-with Unchecked_Conversion;
+with Ada.Unchecked_Conversion;
 
 package body AUnit.Memory is
 
@@ -49,7 +49,7 @@ package body AUnit.Memory is
 
    Top : Mark_Id := Mem'First;
 
-   function To_Mark_Id is new Unchecked_Conversion
+   function To_Mark_Id is new Ada.Unchecked_Conversion
      (size_t, Mark_Id);
 
    -----------

--- a/include/aunit/framework/zfpexception/aunit-test_cases-call_set_up_case.adb
+++ b/include/aunit/framework/zfpexception/aunit-test_cases-call_set_up_case.adb
@@ -37,6 +37,8 @@ function Call_Set_Up_Case
   (Test : in out Test_Case'Class) return Test_Error_Access is
    function Alloc_Error is new Gen_Alloc (Test_Error, Test_Error_Access);
 
+   procedure Internal_Set_Up_Case;
+
    procedure Internal_Set_Up_Case is
    begin
       Set_Up_Case (Test);

--- a/include/aunit/reporters/aunit-reporter-junit.adb
+++ b/include/aunit/reporters/aunit-reporter-junit.adb
@@ -33,7 +33,11 @@ with AUnit.IO;              use AUnit.IO;
 with AUnit.Time_Measure;    use AUnit.Time_Measure;
 
 package body AUnit.Reporter.JUnit is
-   
+
+   procedure Put_Special_Chars (File : File_Type; S : String);
+   procedure Report_Test (File : File_Type; Test : Test_Result);
+   procedure Dump_Result_List (File : File_Type; L : Result_Lists.List);
+
    procedure Put_Special_Chars (File : File_Type; S : String) is
    begin
       for C of S loop
@@ -46,10 +50,10 @@ package body AUnit.Reporter.JUnit is
          end case;
       end loop;
    end Put_Special_Chars;
-   
+
    procedure Put_Measure is
      new Gen_Put_Measure_In_Seconds;
-   
+
    procedure Report_Test (File : File_Type; Test : Test_Result) is
    begin
       Put (File, "<testcase name=""");
@@ -59,7 +63,7 @@ package body AUnit.Reporter.JUnit is
       Put (File, """ time=""");
       Put_Measure (File, Get_Measure (Test.Elapsed));
       if Test.Failure /= null then
-         Put_Line (File, """>"); 
+         Put_Line (File, """>");
          Put_Line (File, "<failure>");
          Put_Line (File, "<![CDATA[");
          Put (File, "        Assertion: ");
@@ -73,7 +77,7 @@ package body AUnit.Reporter.JUnit is
          Put_Line (File, "</failure>");
          Put_Line (File, "</testcase>");
       elsif Test.Error /= null then
-         Put_Line (File, """>"); 
+         Put_Line (File, """>");
          Put_Line (File, "<error>");
          Put_Line (File, "<![CDATA[");
          Put (File, "      Exception: ");
@@ -90,9 +94,9 @@ package body AUnit.Reporter.JUnit is
          Put_Line (File, "</testcase>");
       else
          Put_Line (File, """ />");
-      end if;      
+      end if;
    end Report_Test;
-   
+
    procedure Dump_Result_List (File : File_Type; L : Result_Lists.List) is
       use Result_Lists;
       C : Cursor := First (L);
@@ -102,17 +106,19 @@ package body AUnit.Reporter.JUnit is
          Next (C);
       end loop;
    end Dump_Result_List;
-   
+
    procedure Report (Engine  : JUnit_Reporter;
                      R       : in out Result'Class;
                      Options : AUnit_Options := Default_Options)
-   is     
+   is
       File : File_Type renames Engine.File.all;
       T    : constant Time := Elapsed (R);
    begin
       Put_Line (File, "<?xml version=""1.0"" encoding=""utf-8""?>");
       Put_Line (File, "<testsuites>");
-      Put (File, "<testsuite name=""" & "aunit_testsuite" & """ skipped=""0"" tests=""");
+      Put (File, "<testsuite name=""" &
+                 "aunit_testsuite" &
+                 """ skipped=""0"" tests=""");
       Put (File, Integer (Test_Count (R)), 0);
       Put (File, """ failures=""");
       Put (File, Integer (Failure_Count (R)), 0);
@@ -122,7 +128,7 @@ package body AUnit.Reporter.JUnit is
          Put (File, """ time=""");
          Put_Measure (File, Get_Measure (T));
       end if;
-      Put_Line (File, """>");      
+      Put_Line (File, """>");
       if Options.Report_Successes then
          declare
             S : Result_Lists.List;
@@ -130,7 +136,7 @@ package body AUnit.Reporter.JUnit is
             Successes (R, S);
             Dump_Result_List (File, S);
          end;
-      end if;      
+      end if;
       declare
          F : Result_Lists.List;
       begin
@@ -142,7 +148,7 @@ package body AUnit.Reporter.JUnit is
       begin
          Errors (R, E);
          Dump_Result_List (File, E);
-      end;      
+      end;
       Put_Line (File, "</testsuite>");
       Put_Line (File, "</testsuites>");
    end Report;

--- a/include/aunit/reporters/aunit-reporter-junit.ads
+++ b/include/aunit/reporters/aunit-reporter-junit.ads
@@ -31,9 +31,9 @@
 
 --  jenkins-junit.xsd compatible reporter to file.
 package AUnit.Reporter.JUnit is
-   
+
    type JUnit_Reporter is new Reporter with null record;
-      
+
    procedure Report (Engine  : JUnit_Reporter;
                      R       : in out Result'Class;
                      Options : AUnit_Options := Default_Options);

--- a/include/aunit/reporters/aunit-reporter-text.adb
+++ b/include/aunit/reporters/aunit-reporter-text.adb
@@ -38,13 +38,19 @@ package body AUnit.Reporter.Text is
    procedure Indent (File : File_Type; N : Natural);
    --  Print N indentations to output
 
-   procedure Dump_Result_List (File : File_Type; L : Result_Lists.List; Prefix : String);
+   procedure Dump_Result_List
+      (File   : File_Type;
+       L      : Result_Lists.List;
+       Prefix : String);
    --  Dump a result list
 
    procedure Put_Measure is new Gen_Put_Measure;
    --  Output elapsed time
 
-   procedure Report_Test (File : File_Type; Test : Test_Result; Prefix : String);
+   procedure Report_Test
+      (File   : File_Type;
+       Test   : Test_Result;
+       Prefix : String);
    --  Report a single assertion failure or unexpected exception
 
    generic
@@ -88,8 +94,11 @@ package body AUnit.Reporter.Text is
    -- Dump_Result_List --
    ----------------------
 
-   procedure Dump_Result_List (File : File_Type; L : Result_Lists.List; Prefix : String) is
-
+   procedure Dump_Result_List
+      (File   : File_Type;
+       L      : Result_Lists.List;
+       Prefix : String)
+   is
       use Result_Lists;
 
       C : Cursor := First (L);
@@ -211,7 +220,11 @@ package body AUnit.Reporter.Text is
    -- Report_Test --
    -----------------
 
-   procedure Report_Test (File : File_Type; Test : Test_Result; Prefix : String) is
+   procedure Report_Test
+      (File   : File_Type;
+       Test   : Test_Result;
+       Prefix : String)
+   is
       T : AUnit_Duration;
    begin
       Put (File, Prefix);


### PR DESCRIPTION
This warning breaks my tests with GNAT FSF 13.2.1 in the Alire CI environment.

https://github.com/alire-project/alire-index/actions/runs/7681838264/job/20986832061?pr=978#step:6:825
https://github.com/alire-project/alire-index/pull/978

@Fabien-Chouteau 